### PR TITLE
externpro 25.07.6-25-g0a8d87a

### DIFF
--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,0 +1,2 @@
+tag: v1.3.1.3
+message: "externpro version 1.3.1.3 tag"

--- a/.github/release-tag.yml
+++ b/.github/release-tag.yml
@@ -1,2 +1,2 @@
-tag: v1.3.1.3
-message: "externpro version 1.3.1.3 tag"
+tag: xpv1.3.1.4
+message: "xpro version 1.3.1.4 tag"

--- a/.github/workflows/xpbuild.yml
+++ b/.github/workflows/xpbuild.yml
@@ -1,12 +1,12 @@
-name: Build
+name: xpBuild
 permissions:
   contents: read
   pull-requests: write
 on:
   push:
-    branches: [ "dev" ]
+    tags: ["xpv*"]
   pull_request:
-    branches: [ "dev" ]
+    branches: ["xpro"]
   workflow_dispatch:
 jobs:
   linux:
@@ -14,11 +14,11 @@ jobs:
       contents: read
       pull-requests: write
       packages: write
-    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07
+    uses: externpro/externpro/.github/workflows/build-linux.yml@25.07.6
     secrets: inherit
   macos:
-    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07
+    uses: externpro/externpro/.github/workflows/build-macos.yml@25.07.6
     secrets: inherit
   windows:
-    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07
+    uses: externpro/externpro/.github/workflows/build-windows.yml@25.07.6
     secrets: inherit

--- a/.github/workflows/xprelease.yml
+++ b/.github/workflows/xprelease.yml
@@ -1,4 +1,4 @@
-name: Release
+name: xpRelease
 on:
   workflow_dispatch:
     inputs:
@@ -6,10 +6,35 @@ on:
         description: 'URL of the workflow run containing artifacts to upload (e.g., https://github.com/owner/repo/actions/runs/123456789)'
         required: true
         type: string
+  workflow_run:
+    workflows: ["xpBuild"]
+    types: [completed]
 jobs:
+  dispatch-at-tag:
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'xpv')
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      -
+        name: Dispatch xpRelease at tag
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          TAG_REF: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          set -euo pipefail
+          gh api -X POST "repos/${{ github.repository }}/actions/workflows/xprelease.yml/dispatches" \
+            -f ref="$TAG_REF" \
+            -f inputs[workflow_run_url]="$RUN_URL"
   # Upload build artifacts as release assets
   release-from-build:
-    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07
+    if: github.event_name == 'workflow_dispatch'
+    uses: externpro/externpro/.github/workflows/release-from-build.yml@25.07.6
     with:
       workflow_run_url: ${{ github.event.inputs.workflow_run_url }}
     permissions:

--- a/.github/workflows/xptag.yml
+++ b/.github/workflows/xptag.yml
@@ -1,0 +1,16 @@
+name: xpTag
+permissions:
+  contents: write
+  issues: write
+on:
+  pull_request:
+    types: [closed]
+jobs:
+  tag:
+    if: ${{ github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'xpro' && contains(github.event.pull_request.labels.*.name, 'release:tag') }}
+    uses: externpro/externpro/.github/workflows/tag-release.yml@25.07.6
+    with:
+      merge_sha: ${{ github.event.pull_request.merge_commit_sha }}
+      pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      workflow_write_token: ${{ secrets.XPUPDATE_TOKEN }}


### PR DESCRIPTION
## Summary

Update externpro submodule to `25.07.6-25-g0a8d87a`

## Changes

- Updated `.devcontainer` to externpro `25.07.6-25-g0a8d87a`
- Previous HEAD: `ad67bce5fb63e89f6f8c0fbffda1c1baccaaca26`
- New HEAD: `0a8d87ab66d39783e66885d6f1c1517071672c94`
- Created `.github/release-tag.yml` (tag: `v1.3.1.3`)
- If you add the \"release:tag\" label, the tag will be \`v1.3.1.3\`
  - WARNING: that tag already exists; update \".github/release-tag.yml\" to the next desired tag value
    - https://github.com/externpro/zlib/blob/externpro-update-25.07.6-25-g0a8d87a-21794179125-1/.github/release-tag.yml
- Updated caller workflows to match templates

### Workflow Update Report

✓ xpbuild.yml: Version updated 25.07 → 25.07.6
✓ xpbuild.yml: workflow name updated from template
✓ xpbuild.yml: push.branches updated from template
✓ xpbuild.yml: push.tags updated from template
✓ xpbuild.yml: pull_request.branches updated from template
✓ xprelease.yml: Synced from template
✓ xptag.yml: Created new workflow from template

---

*This PR was created automatically by GitHub Actions*
